### PR TITLE
Отключение миграции на экипировку НКР и тренч следователя

### DIFF
--- a/Resources/Migrations/N14Migrations.yml
+++ b/Resources/Migrations/N14Migrations.yml
@@ -9,11 +9,11 @@
 # Table: null
 
 # DD/MM/YYYY like a real human being.
-N14ClothingHeadHatNCRHelmetMetal: N14ClothingHeadHatNCRHelmetMetalSnow
-# N14ClothingOfficerUniformNCR: N14ClothingOfficerUniformNCRSnow
-# N14ClothingUniformNCR: N14ClothingUniformNCRSnow
+# Forge-Change-Del
+# Forge-Change-Del
+# Forge-Change-Del
 N14ClothingOuterNCRPouchedVest: N14ClothingOuterNCRPouchedVestDesert
-# N14ClothingOuterNCRVest: N14ClothingOuterNCRVestSnow
+# Forge-Change-Del
 N14BedrollItem: N14Bedroll
 N14JunkStackedTires: N14JunkTire1
 N14JunkGroundTires: N14JunkTire2

--- a/Resources/Migrations/N14Migrations.yml
+++ b/Resources/Migrations/N14Migrations.yml
@@ -9,11 +9,11 @@
 # Table: null
 
 # DD/MM/YYYY like a real human being.
-# Forge-Change-Del
-# Forge-Change-Del
-# Forge-Change-Del
+# N14ClothingHeadHatNCRHelmetMetal: N14ClothingHeadHatNCRHelmetMetalSnow # Forge-Change-Del
+# N14ClothingOfficerUniformNCR: N14ClothingOfficerUniformNCRSnow # Forge-Change-Del
+# N14ClothingUniformNCR: N14ClothingUniformNCRSnow # Forge-Change-Del
 N14ClothingOuterNCRPouchedVest: N14ClothingOuterNCRPouchedVestDesert
-# Forge-Change-Del
+# N14ClothingOuterNCRVest: N14ClothingOuterNCRVestSnow # Forge-Change-Del
 N14BedrollItem: N14Bedroll
 N14JunkStackedTires: N14JunkTire1
 N14JunkGroundTires: N14JunkTire2

--- a/Resources/Migrations/N14Migrations.yml
+++ b/Resources/Migrations/N14Migrations.yml
@@ -10,10 +10,10 @@
 
 # DD/MM/YYYY like a real human being.
 N14ClothingHeadHatNCRHelmetMetal: N14ClothingHeadHatNCRHelmetMetalSnow
-N14ClothingOfficerUniformNCR: N14ClothingOfficerUniformNCRSnow
-N14ClothingUniformNCR: N14ClothingUniformNCRSnow
+# N14ClothingOfficerUniformNCR: N14ClothingOfficerUniformNCRSnow
+# N14ClothingUniformNCR: N14ClothingUniformNCRSnow
 N14ClothingOuterNCRPouchedVest: N14ClothingOuterNCRPouchedVestDesert
-N14ClothingOuterNCRVest: N14ClothingOuterNCRVestSnow
+# N14ClothingOuterNCRVest: N14ClothingOuterNCRVestSnow
 N14BedrollItem: N14Bedroll
 N14JunkStackedTires: N14JunkTire1
 N14JunkGroundTires: N14JunkTire2

--- a/Resources/Migrations/migration.yml
+++ b/Resources/Migrations/migration.yml
@@ -259,7 +259,7 @@ DoorRemoteFirefight: null
 AirlockServiceCaptainLocked: AirlockCaptainLocked
 
 # 2024-06-15
-# ClothingOuterCoatInspector: ClothingOuterCoatDetectiveLoadout Forge-Change
+ClothingOuterCoatDetectiveLoadout: ClothingOuterCoatInspector # Поменял местами Forge-Chage
 
 # 2024-06-23
 FloorTileItemReinforced: PartRodMetal1

--- a/Resources/Migrations/migration.yml
+++ b/Resources/Migrations/migration.yml
@@ -259,7 +259,7 @@ DoorRemoteFirefight: null
 AirlockServiceCaptainLocked: AirlockCaptainLocked
 
 # 2024-06-15
-ClothingOuterCoatInspector: ClothingOuterCoatDetectiveLoadout
+# ClothingOuterCoatInspector: ClothingOuterCoatDetectiveLoadout Forge-Change
 
 # 2024-06-23
 FloorTileItemReinforced: PartRodMetal1


### PR DESCRIPTION
Миграция на изменение зимних вариантов НКР-овской экипировки отключена. Они больше не будут мигрировать под зиму, но и нынешние уже мигрированные образцы нужно будет изменить мапперам под пустыню в ручную. 
Теперь тренч детектива становится пальтом инспектора всегда.

N14ClothingOuterNCRVestSnow
N14ClothingOfficerUniformNCRSnow
N14ClothingHeadHatNCRHelmetMetalSnow
N14ClothingUniformNCRSnow

Эти предметы удалены из миграции, их можно изменить на пустынные варианты.
